### PR TITLE
Change inputs to 'tel' for number input on mobile

### DIFF
--- a/src/components/Calculator.js
+++ b/src/components/Calculator.js
@@ -140,7 +140,7 @@ class Calculator extends Component {
                 guide={false}
                 className="input input--blood"
                 name="blood"
-                type="text"
+                type="tel"
                 placeholder="Blood Glucose"
                 value={this.state.blood}
                 onChange={event => this.setState({ blood: event.target.value })}
@@ -162,7 +162,7 @@ class Calculator extends Component {
                 guide={false}
                 className="input input--isig"
                 name="isig"
-                type="text"
+                type="tel"
                 placeholder="ISIG"
                 value={this.state.isig}
                 onChange={event => this.setState({ isig: event.target.value })}


### PR DESCRIPTION
Tested Chrome, Edge, and Firefox on desktop. I assume the mobile versions of these browsers will follow suit. Placeholders still remain as letters, but when clicking to type, only numbers are allowed.